### PR TITLE
Improved version handling

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -56,18 +56,109 @@
           "size": 108103275
         },
         {
-          "version": "1.1.7",
+          "version": "1.1.7b",
           "date": "2024-11-02T05:56:30Z",
           "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\r\nImprovedCustomApi .DEB Version: \"1.1.7b\"\r\n\r\n**RELEASE \"1.15.11\"\u2022\"1.1.7b\":** (2024/11/02)\r\n\u2022 Updated ImprovedCustomApi from \"1.1.7\" to \"1.1.7b\"\r\n  \u2022  Add rootless package support to Theos build workflow (https://github.com/JeffreyCA/Apollo\u2022ImprovedCustomApi/pull/46) \u2022 thanks @darkxdd\\r\\n\\r\\n(There are no functionality changes in this release)\r\n\r\nKnown issues\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
           "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.1.7b/Apollo-1.15.11_improvedcustomapi-1.1.7b.ipa",
           "size": 108102952
         },
         {
-          "version": "1.15.11",
+          "version": "1.1.7",
           "date": "2024-10-20T01:10:52Z",
           "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.7\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.7\":** (2024/10/20)\n\u2022 Updated ImprovedCustomApi from \"1.1.6\" to \"1.1.7\"\n  \u2022 Improve parsing  and  links\r\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
           "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.7/Apollo-1.15.11_improvedcustomapi-1.1.7.ipa",
           "size": 108281478
+        },
+        {
+          "version": "1.1.6",
+          "date": "2024-10-06T01:09:56Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.6\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.6\":** (2024/10/06)\n\u2022 Updated ImprovedCustomApi from \"1.1.5b\" to \"1.1.6\"\n  \u2022 \u2022 Fix issue with share URLs not working after device locks\r\n\u2022 Remove unused code for handling Imgur links\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.6/Apollo-1.15.11_improvedcustomapi-1.1.6.ipa",
+          "size": 108282728
+        },
+        {
+          "version": "1.1.5b",
+          "date": "2024-09-20T00:28:59Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.5b\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.5b\":** (2024/09/20)\n\u2022 Updated ImprovedCustomApi from \"1.1.4\" to \"1.1.5b\"\n  \u2022 \u2022 Fix rare crashing issue\r\n\u2022 Include tweak version in Custom API settings view\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.5b/Apollo-1.15.11_improvedcustomapi-1.1.5b.ipa",
+          "size": 108282519
+        },
+        {
+          "version": "1.1.4",
+          "date": "2024-08-30T01:00:59Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.4\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.4\":** (2024/09/18)\n\u2022 Updated ImprovedCustomApi from \"1.1.3\" to \"1.1.4\"\n  \u2022 \u2022 Improve share URL and Imgur link parsing (specifically URLs formatted like: )\r\n\u2022 Fix crashing issue when loading content\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.4/Apollo-1.15.11_improvedcustomapi-1.1.4.ipa",
+          "size": 108282530
+        },
+        {
+          "version": "1.1.3",
+          "date": "2024-08-24T12:10:24Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.3\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.3\":** (2024/08/24)\n\u2022 Updated ImprovedCustomApi from \"1.1.2\" to \"1.1.3\"\n  \u2022 Fix issue with some newer Imgur images and albums not loading properly (35)\r\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.3/Apollo-1.15.11_improvedcustomapi-1.1.3.ipa",
+          "size": 108281984
+        },
+        {
+          "version": "1.1.2",
+          "date": "2024-08-02T07:24:21Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.2\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.2\":** (2024/08/03)\n\u2022 Updated ImprovedCustomApi from \"1.1.1\" to \"1.1.2\"\n  \u2022 Update user agent to fix multireddit search (33) \u2022 thanks @paradoxally and @blvdmd!\r\n\r\n[Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36](https://useragents.io/uas/mozilla\u20225\u20220\u2022macintosh\u2022intel\u2022mac\u2022os\u2022x\u202210\u202215\u20227\u2022applewebkit\u2022537\u202236\u2022khtml\u2022like\u2022gecko\u2022chrome\u202291\u20220\u20224472\u2022114\u2022safari\u2022537\u202236\u2022gzipgfe_2497d28276f9d0c8d383700f3c2f7c9e)\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.2/Apollo-1.15.11_improvedcustomapi-1.1.2.ipa",
+          "size": 108281925
+        },
+        {
+          "version": "1.1.1",
+          "date": "2024-07-31T19:21:54Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.1.1\" \r\n\r\n**RELEASE 1.15.11\u20221.1.1:** (2024\u202207\u202231)\r\n\u2022 Working hybrid implementation of the \"New Comments Highlighter\" Ultra feature \u2022 it's a custom implementation so it may not behave exactly like the original. Enable the feature in Settings \u2022> General \u2022> Custom API, not Settings \u2022> General as it crashes the app.\r\n\u2022 Add [FLEX integration](https://github.com/FLEXTool/FLEX) for debugging purposes. Use at your own risk! Requires app restart after enabling in Settings \u2022> General \u2022> Custom API.\r\n        Note: the .deb package is larger in size as a result\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.1/Apollo-1.15.11_improvedcustomapi-1.1.1.ipa",
+          "size": 108681149
+        },
+        {
+          "version": "1.0.12",
+          "date": "2024-07-26T18:49:20Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.12\" \r\n\r\n**RELEASE 1.15.11\u20221.0.11:** (2024\u202207\u202226)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.11\" to \"1.0.12\" \r\n    \u2022 Use a more generic user agent independent of bundle ID for requests to Reddit\r\n\r\n[Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1](https://useragents.io/explore/platforms/ios/maker/apple\u2022inc\u2022b93/uas/mozilla\u20225\u20220\u2022iphone\u2022cpu\u2022iphone\u2022os\u202217\u20225\u20221\u2022like\u2022mac\u2022os\u2022x\u2022applewebkit\u2022605\u20221\u202215\u2022khtml\u2022like\u2022gecko\u2022version\u202217\u20225\u2022mobile\u202215e148\u2022safari\u2022604\u20221_2f39fc840d9054105730c511db1920b7)\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.12/Apollo-1.15.11_improvedcustomapi-1.0.12.ipa",
+          "size": 108152923
+        },
+        {
+          "version": "1.0.11",
+          "date": "2024-02-28T12:33:18Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.11\" \r\n\r\n**RELEASE 1.15.11\u20221.0.11:** (2024\u202202\u202228)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.10\" to \"1.0.11\" \r\n    \u2022 Fix issue with Imgur uploads consistently failing. Note that multi\u2022image uploads may still fail on the first attempt.\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.11/Apollo-1.15.11_improvedcustomapi-1.0.11.ipa",
+          "size": 108157689
+        },
+        {
+          "version": "1.0.10",
+          "date": "2024-01-23T12:32:35Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.10\" \r\n\r\n**RELEASE 1.15.11\u20221.0.9:** (2024\u202201\u202223)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.9\" to \"1.0.10\" \r\n   \u2022 Add support for /u/ share links (e.g. \"reddit.com/u/username/s/xxxxxx\")\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.10/Apollo-1.15.11_improvedcustomapi-1.0.10.ipa",
+          "size": 108157865
+        },
+        {
+          "version": "1.0.9",
+          "date": "2023-12-30T08:52:04Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.9\" \r\n\r\n**RELEASE 1.15.11\u20221.0.9:** (2023\u202212\u202230)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.8\" to \"1.0.9\" \r\n   \u2022 Randomize \"trending subreddits\" list so it doesn't show iOS, Clock, Time, IfYouDontMind all the time \u2022 thanks @iCrazeiOS!\r\n      \u2022 Context: There isn't an official Reddit API to get the currently trending subreddits. Apollo has a hardcoded mapping of dates to trending subreddits in this file called trending\u2022subreddits.plist that is bundled inside the .ipa. The last date entry is 2023\u20229\u20229, which is why Apollo has been falling back to the default iOS, Clock, Time, IfYouDontMind subreddits lately.\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.9/Apollo-1.15.11_improvedcustomapi-1.0.9.ipa",
+          "size": 108157858
+        },
+        {
+          "version": "1.0.8",
+          "date": "2023-12-16T15:09:37Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.8\" \r\n\r\n**RELEASE 1.15.11\u20221.0.8:** (2023\u202212\u202216)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.7\" to \"1.0.8\" \r\n   \u2022 Lower minimum iOS version requirement to 14.0\r\n   \u2022 Toggleable settings for blocking announcements and some Ultra settings (not fully working, see https://github.com/JeffreyCA/Apollo\u2022ImprovedCustomApi/issues/1). These are the same as the previous experimental builds.\r\n        \u2022 All toggles are located in Settings \u2022> General \u2022> Custom API\r\n        \u2022 New Comments Highlightifier shows new comment count badge, but doesn't highlight comments inside a thread\r\n        \u2022 Subreddit Weather and Time widget doesn't seem to work (not showing or loads infinitely)\r\n \r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.8/Apollo-1.15.11_improvedcustomapi-1.0.8.ipa",
+          "size": 108157000
+        },
+        {
+          "version": "1.0.7",
+          "date": "2023-12-08T12:08:07Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.7\" \r\n\r\n**RELEASE 1.15.11\u20221.0.7:** (2023\u202212\u202208)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.5\" to \"1.0.7\" \r\n   \u2022 Add support for resolving Reddit media share links (https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2F) (https://github.com/JeffreyCA/Apollo\u2022ImprovedCustomApi/pull/9) \u2022 thanks @mmshivesh!\r\n   \u2022 Add toggleable settings for blocking announcements and some Ultra settings (not working)\r\n   \u2022 Lower minimum iOS version requirement\r\n \r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.7/Apollo-1.15.11_improvedcustomapi-1.0.7.ipa",
+          "size": 108156033
+        },
+        {
+          "version": "1.0.5",
+          "date": "2023-12-04T10:09:25Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.5\" \r\n\r\n**RELEASE 1.15.11\u20221.0.5:** (2023\u202212\u202204)\r\n\u2022 Initial release with ImprovedCustomApi \"1.0.5\" instead of Artemis\r\n   \u2022 Fix crash when tapping on spoiler tag\r\n \r\n**Features**\r\n\u2022 Use Apollo for Reddit with your own Reddit and Imgur API keys\r\n\u2022 Working Imgur integration (view, delete, and upload single images and multi\u2022image albums)\r\n\u2022 Handle x.com links as Twitter links so that they can be opened in the Twitter app\r\n\u2022 Suppress unwanted messages on app startup (wallpaper popup, in\u2022app announcements, etc)\r\n\u2022 Support new share link format (reddit.com/r/subreddit/s/xxxxxx) so they open like any other post and not in a browser\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.5/Apollo-1.15.15_improvedcustomapi-1.0.5.ipa",
+          "size": 108155800
         }
       ],
       "appPermissions": {

--- a/apps.json
+++ b/apps.json
@@ -14,7 +14,7 @@
       "bundleIdentifier": "com.christianselig.Apollo",
       "developerName": "Christian Selig (& JeffreyCA)",
       "subtitle": "The award-winning Reddit app",
-      "version": "1.15.11",
+      "version": "1.2.2",
       "versionDate": "2025-03-06T08:33:31Z",
       "versionDescription": "Apollo version: \"1.15.11\"\nImprovedCustomApi version: \"1.2.2\"\n\nRelease Notes\n\u2022 Fix video downloads failing on certain v.redd.it videos (25, 55)\r\n\r\nNote that the \".deb\" file is significantly larger due to some new external dependencies needed to fix the issue (FFmpegKit).\nKnown Issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser\n",
       "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.2.2/Apollo-1.15.11_ImprovedCustomApi-1.2.2.ipa",
@@ -35,11 +35,39 @@
       ],
       "versions": [
         {
-          "version": "1.15.11",
+          "version": "1.2.2",
           "date": "2025-03-06T08:33:31Z",
           "localizedDescription": "Apollo version: \"1.15.11\"\nImprovedCustomApi version: \"1.2.2\"\n\nRelease Notes\n\u2022 Fix video downloads failing on certain v.redd.it videos (25, 55)\r\n\r\nNote that the \".deb\" file is significantly larger due to some new external dependencies needed to fix the issue (FFmpegKit).\nKnown Issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser\n",
           "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.2.2/Apollo-1.15.11_ImprovedCustomApi-1.2.2.ipa",
           "size": 114650898
+        },
+        {
+          "version": "1.2.1",
+          "date": "2025-01-04T08:01:48Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\r\nImprovedCustomApi .DEB Version: \"1.2.1\"\r\n\r\n**RELEASE \"1.15.11\"\u2022\"1.2.1\":** (2025/01/04)\r\n\u2022 Updated ImprovedCustomApi from \"[1.1.8](https://github.com/Balackburn/Apollo/releases/tag/v1.15.11_1.1.8)\" to \"1.2.1\"\r\n  \u2022 \u2022 Custom random and trending subreddits \u2022 you can now specify an external URL to use as the source for random and trending subreddits (in Settings > General > Custom API)\\r\\n    \u2022 Sources should be a plaintext file with one subreddit name per line, without the  prefix (see examples below)\\r\\n    \u2022 Default trending source (data from [gummysearch.com](https://gummysearch.com/tools/top\u2022subreddits/)): https://jeffreyca.github.io/subreddits/trending\u2022gummy\u2022daily.txt\\r\\n    \u2022 Default /r/random source: https://jeffreyca.github.io/subreddits/popular.txt\\r\\n    \u2022 New setting to customize how many trending subreddits to show (requires app restart)\\r\\n    \u2022 New setting to show a dedicated RandNSFW button (requires app restart)\\r\\n\u2022 Minor UI updates to the settings view\\r\\n\u2022 URL optimizations (52) \u2022 thanks @ryannair05!\r\n\r\nKnown issues\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.2.1/Apollo-1.15.11_improvedcustomapi-1.2.1.ipa",
+          "size": 108107473
+        },
+        {
+          "version": "1.1.8",
+          "date": "2024-12-08T12:18:12Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.8\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.8\":** (2024/12/08)\n\u2022 Updated ImprovedCustomApi from \"1.1.7b\" to \"1.1.8\"\n  \u2022 \u2022 Fix RedGIFs links loading without sound (48) \u2022 thank you @iCrazeiOS!\\r\\n\n\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.1.8/Apollo-1.15.11_improvedcustomapi-1.1.8.ipa",
+          "size": 108103275
+        },
+        {
+          "version": "1.1.7",
+          "date": "2024-11-02T05:56:30Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\r\nImprovedCustomApi .DEB Version: \"1.1.7b\"\r\n\r\n**RELEASE \"1.15.11\"\u2022\"1.1.7b\":** (2024/11/02)\r\n\u2022 Updated ImprovedCustomApi from \"1.1.7\" to \"1.1.7b\"\r\n  \u2022  Add rootless package support to Theos build workflow (https://github.com/JeffreyCA/Apollo\u2022ImprovedCustomApi/pull/46) \u2022 thanks @darkxdd\\r\\n\\r\\n(There are no functionality changes in this release)\r\n\r\nKnown issues\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.1.7b/Apollo-1.15.11_improvedcustomapi-1.1.7b.ipa",
+          "size": 108102952
+        },
+        {
+          "version": "1.15.11",
+          "date": "2024-10-20T01:10:52Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.7\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.7\":** (2024/10/20)\n\u2022 Updated ImprovedCustomApi from \"1.1.6\" to \"1.1.7\"\n  \u2022 Improve parsing  and  links\r\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.7/Apollo-1.15.11_improvedcustomapi-1.1.7.ipa",
+          "size": 108281478
         }
       ],
       "appPermissions": {
@@ -99,17 +127,6 @@
     }
   ],
   "news": [
-    {
-      "appID": "com.christianselig.Apollo",
-      "title": "1.15.11_1.2.1 - 04 Jan",
-      "identifier": "release-1.15.11_1.2.1",
-      "caption": "Update of Apollo (with ImprovedCustomApi) now available!",
-      "date": "2025-01-04T08:01:48Z",
-      "tintColor": "3F91FE",
-      "imageURL": "https://raw.githubusercontent.com/Balackburn/Apollo/main/images/news/news_2.webp",
-      "notify": true,
-      "url": "https://github.com/Balackburn/Apollo/releases/tag/v1.15.11_1.2.1"
-    },
     {
       "appID": "com.christianselig.Apollo",
       "title": "1.15.11_1.2.2 - 06 Mar",

--- a/apps_noext.json
+++ b/apps_noext.json
@@ -14,7 +14,7 @@
       "bundleIdentifier": "com.christianselig.Apollo",
       "developerName": "Christian Selig (& JeffreyCA)",
       "subtitle": "The award-winning Reddit app",
-      "version": "1.15.11",
+      "version": "1.2.2",
       "versionDate": "2025-03-06T08:33:31Z",
       "versionDescription": "Apollo version: \"1.15.11\"\nImprovedCustomApi version: \"1.2.2\"\n\nRelease Notes\n\u2022 Fix video downloads failing on certain v.redd.it videos (25, 55)\r\n\r\nNote that the \".deb\" file is significantly larger due to some new external dependencies needed to fix the issue (FFmpegKit).\nKnown Issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser\n",
       "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.2.2/Apollo-1.15.11_ImprovedCustomApi-1.2.2.ipa",
@@ -35,11 +35,39 @@
       ],
       "versions": [
         {
-          "version": "1.15.11",
+          "version": "1.2.2",
           "date": "2025-03-06T08:33:31Z",
           "localizedDescription": "Apollo version: \"1.15.11\"\nImprovedCustomApi version: \"1.2.2\"\n\nRelease Notes\n\u2022 Fix video downloads failing on certain v.redd.it videos (25, 55)\r\n\r\nNote that the \".deb\" file is significantly larger due to some new external dependencies needed to fix the issue (FFmpegKit).\nKnown Issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser\n",
           "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.2.2/NO-EXTENSIONS_Apollo-1.15.11_ImprovedCustomApi-1.2.2.ipa",
           "size": 77849312
+        },
+        {
+          "version": "1.2.1",
+          "date": "2025-01-04T08:01:48Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\r\nImprovedCustomApi .DEB Version: \"1.2.1\"\r\n\r\n**RELEASE \"1.15.11\"\u2022\"1.2.1\":** (2025/01/04)\r\n\u2022 Updated ImprovedCustomApi from \"[1.1.8](https://github.com/Balackburn/Apollo/releases/tag/v1.15.11_1.1.8)\" to \"1.2.1\"\r\n  \u2022 \u2022 Custom random and trending subreddits \u2022 you can now specify an external URL to use as the source for random and trending subreddits (in Settings > General > Custom API)\\r\\n    \u2022 Sources should be a plaintext file with one subreddit name per line, without the  prefix (see examples below)\\r\\n    \u2022 Default trending source (data from [gummysearch.com](https://gummysearch.com/tools/top\u2022subreddits/)): https://jeffreyca.github.io/subreddits/trending\u2022gummy\u2022daily.txt\\r\\n    \u2022 Default /r/random source: https://jeffreyca.github.io/subreddits/popular.txt\\r\\n    \u2022 New setting to customize how many trending subreddits to show (requires app restart)\\r\\n    \u2022 New setting to show a dedicated RandNSFW button (requires app restart)\\r\\n\u2022 Minor UI updates to the settings view\\r\\n\u2022 URL optimizations (52) \u2022 thanks @ryannair05!\r\n\r\nKnown issues\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.2.1/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.2.1.ipa",
+          "size": 71305887
+        },
+        {
+          "version": "1.1.8",
+          "date": "2024-12-08T12:18:12Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.8\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.8\":** (2024/12/08)\n\u2022 Updated ImprovedCustomApi from \"1.1.7b\" to \"1.1.8\"\n  \u2022 \u2022 Fix RedGIFs links loading without sound (48) \u2022 thank you @iCrazeiOS!\\r\\n\n\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.1.8/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.8.ipa",
+          "size": 71301689
+        },
+        {
+          "version": "1.1.7",
+          "date": "2024-11-02T05:56:30Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\r\nImprovedCustomApi .DEB Version: \"1.1.7b\"\r\n\r\n**RELEASE \"1.15.11\"\u2022\"1.1.7b\":** (2024/11/02)\r\n\u2022 Updated ImprovedCustomApi from \"1.1.7\" to \"1.1.7b\"\r\n  \u2022  Add rootless package support to Theos build workflow (https://github.com/JeffreyCA/Apollo\u2022ImprovedCustomApi/pull/46) \u2022 thanks @darkxdd\\r\\n\\r\\n(There are no functionality changes in this release)\r\n\r\nKnown issues\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.1.7b/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.7b.ipa",
+          "size": 71301366
+        },
+        {
+          "version": "1.15.11",
+          "date": "2024-10-20T01:10:52Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.7\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.7\":** (2024/10/20)\n\u2022 Updated ImprovedCustomApi from \"1.1.6\" to \"1.1.7\"\n  \u2022 Improve parsing  and  links\r\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.7/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.7.ipa",
+          "size": 71409709
         }
       ],
       "appPermissions": {
@@ -99,17 +127,6 @@
     }
   ],
   "news": [
-    {
-      "appID": "com.christianselig.Apollo",
-      "title": "1.15.11_1.2.1 - 04 Jan",
-      "identifier": "release-1.15.11_1.2.1",
-      "caption": "Update of Apollo (with ImprovedCustomApi) now available!",
-      "date": "2025-01-04T08:01:48Z",
-      "tintColor": "3F91FE",
-      "imageURL": "https://raw.githubusercontent.com/Balackburn/Apollo/main/images/news/news_2.webp",
-      "notify": true,
-      "url": "https://github.com/Balackburn/Apollo/releases/tag/v1.15.11_1.2.1"
-    },
     {
       "appID": "com.christianselig.Apollo",
       "title": "1.15.11_1.2.2 - 06 Mar",

--- a/apps_noext.json
+++ b/apps_noext.json
@@ -56,18 +56,109 @@
           "size": 71301689
         },
         {
-          "version": "1.1.7",
+          "version": "1.1.7b",
           "date": "2024-11-02T05:56:30Z",
           "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\r\nImprovedCustomApi .DEB Version: \"1.1.7b\"\r\n\r\n**RELEASE \"1.15.11\"\u2022\"1.1.7b\":** (2024/11/02)\r\n\u2022 Updated ImprovedCustomApi from \"1.1.7\" to \"1.1.7b\"\r\n  \u2022  Add rootless package support to Theos build workflow (https://github.com/JeffreyCA/Apollo\u2022ImprovedCustomApi/pull/46) \u2022 thanks @darkxdd\\r\\n\\r\\n(There are no functionality changes in this release)\r\n\r\nKnown issues\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
           "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11_1.1.7b/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.7b.ipa",
           "size": 71301366
         },
         {
-          "version": "1.15.11",
+          "version": "1.1.7",
           "date": "2024-10-20T01:10:52Z",
           "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.7\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.7\":** (2024/10/20)\n\u2022 Updated ImprovedCustomApi from \"1.1.6\" to \"1.1.7\"\n  \u2022 Improve parsing  and  links\r\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
           "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.7/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.7.ipa",
           "size": 71409709
+        },
+        {
+          "version": "1.1.6",
+          "date": "2024-10-06T01:09:56Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.6\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.6\":** (2024/10/06)\n\u2022 Updated ImprovedCustomApi from \"1.1.5b\" to \"1.1.6\"\n  \u2022 \u2022 Fix issue with share URLs not working after device locks\r\n\u2022 Remove unused code for handling Imgur links\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.6/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.6.ipa",
+          "size": 71410959
+        },
+        {
+          "version": "1.1.5b",
+          "date": "2024-09-20T00:28:59Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.5b\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.5b\":** (2024/09/20)\n\u2022 Updated ImprovedCustomApi from \"1.1.4\" to \"1.1.5b\"\n  \u2022 \u2022 Fix rare crashing issue\r\n\u2022 Include tweak version in Custom API settings view\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.5b/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.5b.ipa",
+          "size": 71410750
+        },
+        {
+          "version": "1.1.4",
+          "date": "2024-08-30T01:00:59Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.4\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.4\":** (2024/09/18)\n\u2022 Updated ImprovedCustomApi from \"1.1.3\" to \"1.1.4\"\n  \u2022 \u2022 Improve share URL and Imgur link parsing (specifically URLs formatted like: )\r\n\u2022 Fix crashing issue when loading content\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.4/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.4.ipa",
+          "size": 71410761
+        },
+        {
+          "version": "1.1.3",
+          "date": "2024-08-24T12:10:24Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.3\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.3\":** (2024/08/24)\n\u2022 Updated ImprovedCustomApi from \"1.1.2\" to \"1.1.3\"\n  \u2022 Fix issue with some newer Imgur images and albums not loading properly (35)\r\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.3/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.3.ipa",
+          "size": 71410215
+        },
+        {
+          "version": "1.1.2",
+          "date": "2024-08-02T07:24:21Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"\nImprovedCustomApi .DEB Version: \"1.1.2\"\n\n**RELEASE \"1.15.11\"\u2022\"1.1.2\":** (2024/08/03)\n\u2022 Updated ImprovedCustomApi from \"1.1.1\" to \"1.1.2\"\n  \u2022 Update user agent to fix multireddit search (33) \u2022 thanks @paradoxally and @blvdmd!\r\n\r\n[Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36](https://useragents.io/uas/mozilla\u20225\u20220\u2022macintosh\u2022intel\u2022mac\u2022os\u2022x\u202210\u202215\u20227\u2022applewebkit\u2022537\u202236\u2022khtml\u2022like\u2022gecko\u2022chrome\u202291\u20220\u20224472\u2022114\u2022safari\u2022537\u202236\u2022gzipgfe_2497d28276f9d0c8d383700f3c2f7c9e)\nKnown issues\n\u2022 Apollo Ultra features may cause app to crash\n\u2022 Imgur multi\u2022image upload\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.2/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.2.ipa",
+          "size": 71410156
+        },
+        {
+          "version": "1.1.1",
+          "date": "2024-07-31T19:21:54Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.1.1\" \r\n\r\n**RELEASE 1.15.11\u20221.1.1:** (2024\u202207\u202231)\r\n\u2022 Working hybrid implementation of the \"New Comments Highlighter\" Ultra feature \u2022 it's a custom implementation so it may not behave exactly like the original. Enable the feature in Settings \u2022> General \u2022> Custom API, not Settings \u2022> General as it crashes the app.\r\n\u2022 Add [FLEX integration](https://github.com/FLEXTool/FLEX) for debugging purposes. Use at your own risk! Requires app restart after enabling in Settings \u2022> General \u2022> Custom API.\r\n        Note: the .deb package is larger in size as a result\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.1.1/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.1.1.ipa",
+          "size": 71809380
+        },
+        {
+          "version": "1.0.12",
+          "date": "2024-07-26T18:49:20Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.12\" \r\n\r\n**RELEASE 1.15.11\u20221.0.11:** (2024\u202207\u202226)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.11\" to \"1.0.12\" \r\n    \u2022 Use a more generic user agent independent of bundle ID for requests to Reddit\r\n\r\n[Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1](https://useragents.io/explore/platforms/ios/maker/apple\u2022inc\u2022b93/uas/mozilla\u20225\u20220\u2022iphone\u2022cpu\u2022iphone\u2022os\u202217\u20225\u20221\u2022like\u2022mac\u2022os\u2022x\u2022applewebkit\u2022605\u20221\u202215\u2022khtml\u2022like\u2022gecko\u2022version\u202217\u20225\u2022mobile\u202215e148\u2022safari\u2022604\u20221_2f39fc840d9054105730c511db1920b7)\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.12/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.0.12.ipa",
+          "size": 71281154
+        },
+        {
+          "version": "1.0.11",
+          "date": "2024-02-28T12:33:18Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.11\" \r\n\r\n**RELEASE 1.15.11\u20221.0.11:** (2024\u202202\u202228)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.10\" to \"1.0.11\" \r\n    \u2022 Fix issue with Imgur uploads consistently failing. Note that multi\u2022image uploads may still fail on the first attempt.\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.11/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.0.11.ipa",
+          "size": 71285810
+        },
+        {
+          "version": "1.0.10",
+          "date": "2024-01-23T12:32:35Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.10\" \r\n\r\n**RELEASE 1.15.11\u20221.0.9:** (2024\u202201\u202223)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.9\" to \"1.0.10\" \r\n   \u2022 Add support for /u/ share links (e.g. \"reddit.com/u/username/s/xxxxxx\")\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.10/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.0.10.ipa",
+          "size": 71285963
+        },
+        {
+          "version": "1.0.9",
+          "date": "2023-12-30T08:52:04Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.9\" \r\n\r\n**RELEASE 1.15.11\u20221.0.9:** (2023\u202212\u202230)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.8\" to \"1.0.9\" \r\n   \u2022 Randomize \"trending subreddits\" list so it doesn't show iOS, Clock, Time, IfYouDontMind all the time \u2022 thanks @iCrazeiOS!\r\n      \u2022 Context: There isn't an official Reddit API to get the currently trending subreddits. Apollo has a hardcoded mapping of dates to trending subreddits in this file called trending\u2022subreddits.plist that is bundled inside the .ipa. The last date entry is 2023\u20229\u20229, which is why Apollo has been falling back to the default iOS, Clock, Time, IfYouDontMind subreddits lately.\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.9/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.0.9.ipa",
+          "size": 71285979
+        },
+        {
+          "version": "1.0.8",
+          "date": "2023-12-16T15:09:37Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.8\" \r\n\r\n**RELEASE 1.15.11\u20221.0.8:** (2023\u202212\u202216)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.7\" to \"1.0.8\" \r\n   \u2022 Lower minimum iOS version requirement to 14.0\r\n   \u2022 Toggleable settings for blocking announcements and some Ultra settings (not fully working, see https://github.com/JeffreyCA/Apollo\u2022ImprovedCustomApi/issues/1). These are the same as the previous experimental builds.\r\n        \u2022 All toggles are located in Settings \u2022> General \u2022> Custom API\r\n        \u2022 New Comments Highlightifier shows new comment count badge, but doesn't highlight comments inside a thread\r\n        \u2022 Subreddit Weather and Time widget doesn't seem to work (not showing or loads infinitely)\r\n \r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.8/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.0.8.ipa",
+          "size": 71285114
+        },
+        {
+          "version": "1.0.7",
+          "date": "2023-12-08T12:08:07Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.7\" \r\n\r\n**RELEASE 1.15.11\u20221.0.7:** (2023\u202212\u202208)\r\n\u2022 Updated ImprovedCustomApi from \"1.0.5\" to \"1.0.7\" \r\n   \u2022 Add support for resolving Reddit media share links (https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2F) (https://github.com/JeffreyCA/Apollo\u2022ImprovedCustomApi/pull/9) \u2022 thanks @mmshivesh!\r\n   \u2022 Add toggleable settings for blocking announcements and some Ultra settings (not working)\r\n   \u2022 Lower minimum iOS version requirement\r\n \r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n  \u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.7/NO-EXTENSIONS_Apollo-1.15.11_improvedcustomapi-1.0.7.ipa",
+          "size": 71284147
+        },
+        {
+          "version": "1.0.5",
+          "date": "2023-12-04T10:09:25Z",
+          "localizedDescription": "Apollo .IPA Version: \"1.15.11\"  \r\nImprovedCustomApi .DEB Version: \"1.0.5\" \r\n\r\n**RELEASE 1.15.11\u20221.0.5:** (2023\u202212\u202204)\r\n\u2022 Initial release with ImprovedCustomApi \"1.0.5\" instead of Artemis\r\n   \u2022 Fix crash when tapping on spoiler tag\r\n \r\n**Features**\r\n\u2022 Use Apollo for Reddit with your own Reddit and Imgur API keys\r\n\u2022 Working Imgur integration (view, delete, and upload single images and multi\u2022image albums)\r\n\u2022 Handle x.com links as Twitter links so that they can be opened in the Twitter app\r\n\u2022 Suppress unwanted messages on app startup (wallpaper popup, in\u2022app announcements, etc)\r\n\u2022 Support new share link format (reddit.com/r/subreddit/s/xxxxxx) so they open like any other post and not in a browser\r\n\r\n**Known issues**\r\n\u2022 Apollo Ultra features may cause app to crash\r\n\u2022 Imgur multi\u2022image upload\r\n\u2022 Uploads usually fail on the first attempt but subsequent retries should succeed\r\n\u2022 Share URLs in private messages and long\u2022tapping them still open in the in\u2022app browser",
+          "downloadURL": "https://github.com/Balackburn/Apollo/releases/download/v1.15.11-1.0.5/NO-EXTENSIONS_Apollo-1.15.15_improvedcustomapi-1.0.5.ipa",
+          "size": 71283914
         }
       ],
       "appPermissions": {

--- a/update_json.py
+++ b/update_json.py
@@ -2,58 +2,181 @@ import json
 import re
 import requests
 from datetime import datetime
+from typing import Dict, List, Tuple, Any, Optional
 
 
-# Fetch all release information from GitHub
-def fetch_all_releases(repo_url):
-    api_url = f"https://api.github.com/repos/{repo_url}/releases"
+GITHUB_REPO = "Balackburn/Apollo"
+JSON_FILE = "apps.json"
+JSON_NOEXT = "apps_noext.json"
+
+
+def fetch_all_releases() -> List[Dict[str, Any]]:
+    """
+    Fetch all release information from GitHub.
+
+    Returns:
+        List of release objects sorted by publication date (oldest first)
+
+    Raises:
+        requests.RequestException: If the API request fails
+    """
+    api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases"
     headers = {"Accept": "application/vnd.github+json"}
+
     response = requests.get(api_url, headers=headers)
+    response.raise_for_status()  # Raise exception for non 200 OK responses
+
     releases = response.json()
     sorted_releases = sorted(releases, key=lambda x: x["published_at"], reverse=False)
 
     return sorted_releases
 
 
-# Fetch the latest release information from GitHub
-def fetch_latest_release(repo_url):
-    api_url = f"https://api.github.com/repos/{repo_url}/releases"
+def fetch_latest_release() -> Dict[str, Any]:
+    """
+    Fetch the latest release information from GitHub.
+
+    Returns:
+        Latest release object
+
+    Raises:
+        requests.RequestException: If the API request fails
+        ValueError: If no releases are found
+    """
+    api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases"
     headers = {"Accept": "application/vnd.github+json"}
+
     response = requests.get(api_url, headers=headers)
+    response.raise_for_status()
+
     releases = response.json()
     sorted_releases = sorted(releases, key=lambda x: x["published_at"], reverse=True)
 
-    if sorted_releases:
-        return sorted_releases[0]
+    if not sorted_releases:
+        raise ValueError("No release found.")
 
-    raise ValueError("No release found.")
+    return sorted_releases[0]
 
 
-def format_desciption(input):
-    description = input
-    description = re.sub("<[^<]+?>", "", description)  # Remove HTML tags
-    description = re.sub(r"#{1,6}\s?", "", description)  # Remove markdown header tags
+def format_description(input_text: str) -> str:
+    """
+    Format release description by removing HTML tags and markdown formatting.
+
+    Args:
+        input_text: Raw release description
+
+    Returns:
+        Formatted description text
+    """
+    description = input_text
+    description = re.sub(r"<[^<]+?>", "", description)  # HTML tags
+    description = re.sub(r"#{1,6}\s?", "", description)  # Markdown header tags
     description = description.replace(r"\*{2}", "").replace("-", "•").replace("`", '"')
     return description
 
-def get_download_info(release, prefix):
+
+def get_download_info(
+    release: Dict[str, Any], prefix: Optional[str]
+) -> Tuple[Optional[str], Optional[int]]:
+    """
+    Get download URL and size for a specific release asset.
+
+    Args:
+        release: GitHub release object
+        prefix: Asset name prefix to search for (None or "NO-EXTENSIONS")
+
+    Returns:
+        Tuple of (download_url, size) - both can be None if asset not found
+    """
     target_prefix = "NO-EXTENSIONS" if prefix == "NO-EXTENSIONS" else "Apollo"
-    
-    download_url = next(
-        (asset["browser_download_url"] for asset in release["assets"] if asset["name"].startswith(target_prefix)),
-        None,
-    )
-    
-    size = next(
-        (asset["size"] for asset in release["assets"] if asset["browser_download_url"] == download_url),
-        None,
-    )
-    
+
+    download_url = None
+    size = None
+
+    for asset in release.get("assets", []):
+        if asset.get("name", "").startswith(target_prefix) and asset.get(
+            "browser_download_url"
+        ):
+            download_url = asset["browser_download_url"]
+            size = asset.get("size")
+            break
+
     return download_url, size
 
-def update_json_file(json_file, fetched_data_all, fetched_data_latest, prefix):
-    with open(json_file, "r") as file:
-        data = json.load(file)
+
+def parse_version(version_string: str) -> Tuple[str, str]:
+    """
+    Parse version string to extract main version and secondary version if present.
+    Support for both underscore and hyphen separators.
+    
+    Args:
+        version_string: Version string with optional underscore or hyphen component
+        
+    Returns:
+        Tuple of (app_version, tweak_version)
+    """
+    # Support both underscore and hyphen as separators
+    # This captures prior releases which used a different formatting approach
+    version_match = re.search(r"(\d+\.\d+(?:\.\d+)?)(?:[_-](\d+\.\d+\.\d+[a-z]?))?", version_string)
+    
+    if not version_match:
+        raise ValueError(f"Invalid version format: {version_string}")
+        
+    app_version = version_match.group(1)
+    tweak_version = version_match.group(2)
+
+    # Catches edge cases where only major and minor version are present in the tag
+    if tweak_version and tweak_version.count('.') == 1:  # If only major and minor exist
+        tweak_version += ".0"
+    
+    return app_version, tweak_version
+
+
+def get_patch_number(version_string: str) -> int:
+    """
+    Extract patch number from version string.
+
+    Args:
+        version_string: Version string (i.e. "1.2.3_1.2.3")
+
+    Returns:
+        Patch number (third component of version)
+    """
+    _, tweak_version = parse_version(version_string)
+
+    # Extract patch number (third component)
+    _, _, patch = map(int, tweak_version.split("."))
+
+    return patch
+
+
+def update_json_file(
+    json_file: str,
+    fetched_data_all: List[Dict[str, Any]],
+    fetched_data_latest: Dict[str, Any],
+    prefix: Optional[str],
+) -> None:
+    """
+    Update app source JSON file with fetched release information.
+
+    Args:
+        json_file: Path to the app source JSON file to update
+        fetched_data_all: List of all releases
+        fetched_data_latest: Latest release data
+        prefix: Asset name prefix to search for (None or "NO-EXTENSIONS")
+    """
+    try:
+        with open(json_file, "r") as file:
+            data = json.load(file)
+    except (json.JSONDecodeError, FileNotFoundError) as e:
+        raise ValueError(f"Error reading JSON file {json_file}: {str(e)}")
+
+    if (
+        not data.get("apps")
+        or not isinstance(data["apps"], list)
+        or len(data["apps"]) == 0
+    ):
+        raise ValueError("Invalid JSON structure: missing or empty 'apps' array")
 
     app = data["apps"][0]
 
@@ -62,23 +185,28 @@ def update_json_file(json_file, fetched_data_all, fetched_data_latest, prefix):
 
     fetched_versions = []
 
+    # Process all releases
     for release in fetched_data_all:
         full_version = release["tag_name"].lstrip("v")
-        # Keep the whole string but extract version for comparison
-        version_for_comparison = re.search(r"(\d+\.\d+\.\d+)(?:_(\d+\.\d+\.\d+))?", full_version)
-        version = version_for_comparison.group(2) if version_for_comparison.group(2) else version_for_comparison.group(1)
+        
+        # Parse the version for comparison
+        app_version, tweak_version = parse_version(full_version)
+        version = tweak_version
         version_date = release["published_at"]
         fetched_versions.append(version)
 
-        description = release["body"]
+        # Extract and format description
+        description = release.get("body", "")
         keyword = "Apollo for Reddit (with ImprovedCustomApi) Release Information"
         if keyword in description:
             description = description.split(keyword, 1)[1].strip()
 
-        description = format_desciption(description)
+        description = format_description(description)
 
+        # Get download information
         download_url, size = get_download_info(release, prefix)
 
+        # Create version entry
         version_entry = {
             "version": version,
             "date": version_date,
@@ -87,56 +215,61 @@ def update_json_file(json_file, fetched_data_all, fetched_data_latest, prefix):
             "size": size,
         }
 
-        app["versions"] = [v for v in app["versions"] if v["version"] != version]
+        # Remove any existing entry with the same version
+        app["versions"] = [v for v in app["versions"] if v.get("version") != version]
 
+        # Add new entry if download URL is available
         if download_url:
             app["versions"].insert(0, version_entry)
 
+    # Process latest release
     latest_version = fetched_data_latest["tag_name"].lstrip("v")
     tag = fetched_data_latest["tag_name"]
-    version_match = re.search(r"(\d+\.\d+\.\d+)(?:_(\d+\.\d+\.\d+))?", latest_version)
 
-    if version_match:
-        if "_" in full_version and len(version_match.groups()) >= 2:
-            # Use the components from the part after the underscore
-            _, _, patch = map(int, version_match.group(2).split("."))
-    else:
-        raise ValueError("Invalid version format")
-    
+    try:
+        app_version, tweak_version = parse_version(latest_version)
+        version = tweak_version if tweak_version else app_version
+        patch_number = get_patch_number(latest_version)
+    except ValueError as e:
+        raise ValueError(f"Error parsing latest version: {str(e)}")
+
+    # Update app metadata
     app["version"] = version
     app["versionDate"] = fetched_data_latest["published_at"]
+    app["versionDescription"] = format_description(fetched_data_latest.get("body", ""))
 
-    description = format_desciption(fetched_data_latest["body"])
-
-    app["versionDescription"] = description
+    # Find IPA download URL and size
     app["downloadURL"] = next(
         (
             asset["browser_download_url"]
-            for asset in fetched_data_latest["assets"]
-            if asset["name"].endswith(".ipa")
-        ),
-        None,
-    )
-    app["size"] = next(
-        (
-            asset["size"]
-            for asset in fetched_data_latest["assets"]
-            if asset["browser_download_url"] == app["downloadURL"]
+            for asset in fetched_data_latest.get("assets", [])
+            if asset.get("name", "").endswith(".ipa")
+            and asset.get("browser_download_url")
         ),
         None,
     )
 
+    app["size"] = next(
+        (
+            asset["size"]
+            for asset in fetched_data_latest.get("assets", [])
+            if asset.get("browser_download_url") == app["downloadURL"]
+        ),
+        None,
+    )
+
+    # Add news entry if not already present
     if "news" not in data:
         data["news"] = []
 
     news_identifier = f"release-{latest_version}"
-    if not any(item["identifier"] == news_identifier for item in data["news"]):
+    if not any(item.get("identifier") == news_identifier for item in data["news"]):
         formatted_date = datetime.strptime(
             fetched_data_latest["published_at"], "%Y-%m-%dT%H:%M:%SZ"
         ).strftime("%d %b")
 
         # Determine caption and image_url based on patch number
-        if patch == 0:
+        if patch_number == 0:
             caption = "Major update of Apollo (with ImprovedCustomApi) is here!"
             image_url = "https://raw.githubusercontent.com/Balackburn/Apollo/main/images/news/news_1.webp"
         else:
@@ -156,20 +289,34 @@ def update_json_file(json_file, fetched_data_all, fetched_data_latest, prefix):
         }
         data["news"].append(news_entry)
 
-    with open(json_file, "w") as file:
-        json.dump(data, file, indent=2)
+    try:
+        with open(json_file, "w") as file:
+            json.dump(data, file, indent=2)
+    except IOError as e:
+        raise ValueError(f"Error writing to JSON file {json_file}: {str(e)}")
 
 
-# Main function
-def main():
-    repo_url = "Balackburn/Apollo"
-    json = "apps.json"
-    json_noext = "apps_noext.json"
+def main() -> None:
+    """
+    Entrypoint for the GitHub workflow action.
 
-    fetched_data_all = fetch_all_releases(repo_url)
-    fetched_data_latest = fetch_latest_release(repo_url)
-    update_json_file(json, fetched_data_all, fetched_data_latest, None)
-    update_json_file(json_noext, fetched_data_all, fetched_data_latest, "NO-EXTENSIONS")
+    The script runs two passes to populate both the sources (standard and no-extensions).
+    """
+    try:
+        fetched_data_all = fetch_all_releases()
+        fetched_data_latest = fetch_latest_release()
+
+        update_json_file(
+            JSON_FILE, fetched_data_all, fetched_data_latest, None
+        )
+        update_json_file(
+            JSON_NOEXT, fetched_data_all, fetched_data_latest, "NO-EXTENSIONS"
+        )
+
+        print(f"Successfully updated {JSON_FILE} and {JSON_NOEXT}")
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        raise
 
 
 if __name__ == "__main__":

--- a/update_json.py
+++ b/update_json.py
@@ -64,7 +64,9 @@ def update_json_file(json_file, fetched_data_all, fetched_data_latest, prefix):
 
     for release in fetched_data_all:
         full_version = release["tag_name"].lstrip("v")
-        version = re.search(r"(\d+\.\d+\.\d+)", full_version).group(1)
+        # Keep the whole string but extract version for comparison
+        version_for_comparison = re.search(r"(\d+\.\d+\.\d+)(?:_(\d+\.\d+\.\d+))?", full_version)
+        version = version_for_comparison.group(2) if version_for_comparison.group(2) else version_for_comparison.group(1)
         version_date = release["published_at"]
         fetched_versions.append(version)
 
@@ -92,10 +94,12 @@ def update_json_file(json_file, fetched_data_all, fetched_data_latest, prefix):
 
     latest_version = fetched_data_latest["tag_name"].lstrip("v")
     tag = fetched_data_latest["tag_name"]
-    version_match = re.search(r"_(\d+\.\d+\.\d+)", latest_version)
+    version_match = re.search(r"(\d+\.\d+\.\d+)(?:_(\d+\.\d+\.\d+))?", latest_version)
 
     if version_match:
-        _, _, patch = map(int, version_match.group(1).split('.'))
+        if "_" in full_version and len(version_match.groups()) >= 2:
+            # Use the components from the part after the underscore
+            _, _, patch = map(int, version_match.group(2).split("."))
     else:
         raise ValueError("Invalid version format")
     


### PR DESCRIPTION
Hopefully the last set of changes from me :^)

I was having a look at the raw API response from [https://api.github.com/repos/Balackburn/Apollo/releases](https://api.github.com/repos/Balackburn/Apollo/releases) and decided to tackle the version handling.

- Migrated to purely using the tweak version when creating entries.
  - This is because the app version is fixed, so it's not necessary to denote it when writing to the sources.
- Added a check in the event a future tweak release is missing the patch version it will manually append it (i.e. `1.5` -> `1.5.0`).
- Improved the regex function to capture the older releases before you transitioned to using `_` as the separator instead of `-`.
- Added error handling in most places to provide information if something fails or doesn't conform
- Introduced typing and comments to make the code safer and easier to work on in the future.

**Important:**
I'd like to please request you remove the tagged release [v1.15.11-1.4](https://github.com/Balackburn/Apollo/tree/v1.15.11-1.4) that uses Artemis due to the version number. Otherwise the script would have inserted this far higher into the `version` object than it has any right being.
I didn't want to code in a specific check for this one item since that felt kind of bad lol.

Anyway, thanks for allowing me to contribute to this project - it's been a lot of fun!
