### PR TITLE
Build Version with Liquid Glass

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -22,7 +22,10 @@ env:
 
 jobs:
   build-apollo-ipa:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Check out repository
@@ -40,6 +43,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install requests
           pip install --force-reinstall "${{ env.PYZULE_RW_URL }}"
+
+      - name: Install ldid
+        run: brew install ldid
 
       - name: Fetch latest release information
         id: get-release
@@ -72,23 +78,81 @@ jobs:
         id: download-files
         env:
           DEB_URL: ${{ steps.get-release.outputs.DEB_URL }}
+          RELEASE_TAG: ${{ steps.get-release.outputs.RELEASE_TAG }}
         run: |
           curl -L "$APOLLO_IPA_URL" -o Apollo.ipa
           APOLLO_VERSION=$(unzip -p Apollo.ipa 'Payload/*.app/Info.plist' | grep -A1 'CFBundleShortVersionString' | grep string | sed -E 's/<string>(.*)<\/string>/\1/' | tr -d '[:space:]')
-          
+
           curl -L "$DEB_URL" -o improvedcustomapi.deb
-          ICA_VERSION=$(echo "$DEB_URL" | grep -oP 'customapi_\K[0-9\.]+')
 
           echo "APOLLO_VERSION=${APOLLO_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "ICA_VERSION=${ICA_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "ICA_VERSION=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Setup build folders
+        env:
+            APOLLO_VERSION: ${{ steps.download-files.outputs.APOLLO_VERSION }}
+            ICA_VERSION: ${{ steps.download-files.outputs.ICA_VERSION }}
+        run: |
+          mkdir -p "Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}/Payload"
+          mkdir -p "NO-EXTENSIONS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}/Payload"
 
       - name: Build modified .ipa
         env:
             APOLLO_VERSION: ${{ steps.download-files.outputs.APOLLO_VERSION }}
             ICA_VERSION: ${{ steps.download-files.outputs.ICA_VERSION }}
+        working-directory: Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}
         run: |
-          cyan -i Apollo.ipa -o "Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" -f improvedcustomapi.deb --fakesign
-          cyan -i Apollo.ipa -o "NO-EXTENSIONS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" -f improvedcustomapi.deb --fakesign -e
+          cyan -i "${GITHUB_WORKSPACE}/Apollo.ipa" -o "Payload/Apollo.app" -f "${GITHUB_WORKSPACE}/improvedcustomapi.deb" --fakesign
+          echo "Zipping Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa"
+          zip -6 -rq "Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" "Payload" -x "*/.*"
+
+          echo "Updating build version in Apollo Executable!"
+          echo "Previous $(vtool -show-build Payload/Apollo.app/Apollo)"
+          vtool -set-build-version ios 15.0 19.0 -replace -output "Payload/Apollo.app/Apollo" "Payload/Apollo.app/Apollo"
+          echo "Updated $(vtool -show-build Payload/Apollo.app/Apollo)"
+
+          echo "Checking for duplicate LC_RPATH entries..."
+          executable_path_count=$(otool -l "Payload/Apollo.app/Apollo" | grep -A 2 LC_RPATH | grep "@executable_path/Frameworks" | wc -l | tr -d ' ')
+          echo "Found $executable_path_count @executable_path/Frameworks LC_RPATH entries"
+          if [ "$executable_path_count" -gt 1 ]; then
+            echo "Removing duplicate @executable_path/Frameworks LC_RPATH entry..."
+            install_name_tool -delete_rpath "@executable_path/Frameworks" "Payload/Apollo.app/Apollo"
+            echo "Duplicate LC_RPATH entry removed"
+          fi
+
+          echo "Fake Signing Apollo Executable!"
+          ldid -S -M "Payload/Apollo.app/Apollo"
+          echo "Zipping GLASS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa"
+          zip -6 -rq "GLASS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" "Payload" -x "*/.*"
+
+      - name: Build no extension modified .ipa
+        env:
+            APOLLO_VERSION: ${{ steps.download-files.outputs.APOLLO_VERSION }}
+            ICA_VERSION: ${{ steps.download-files.outputs.ICA_VERSION }}
+        working-directory: NO-EXTENSIONS_Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}
+        run: |
+          cyan -i "${GITHUB_WORKSPACE}/Apollo.ipa" -o "Payload/Apollo.app" -f "${GITHUB_WORKSPACE}/improvedcustomapi.deb" --fakesign -e
+          echo "Zipping Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa"
+          zip -6 -rq "NO-EXTENSIONS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" "Payload" -x "*/.*"
+
+          echo "Updating build version in Apollo Executable!"
+          echo "Previous $(vtool -show-build Payload/Apollo.app/Apollo)"
+          vtool -set-build-version ios 15.0 19.0 -replace -output "Payload/Apollo.app/Apollo" "Payload/Apollo.app/Apollo"
+          echo "Updated $(vtool -show-build Payload/Apollo.app/Apollo)"
+
+          echo "Checking for duplicate LC_RPATH entries..."
+          executable_path_count=$(otool -l "Payload/Apollo.app/Apollo" | grep -A 2 LC_RPATH | grep "@executable_path/Frameworks" | wc -l | tr -d ' ')
+          echo "Found $executable_path_count @executable_path/Frameworks LC_RPATH entries"
+          if [ "$executable_path_count" -gt 1 ]; then
+            echo "Removing duplicate @executable_path/Frameworks LC_RPATH entry..."
+            install_name_tool -delete_rpath "@executable_path/Frameworks" "Payload/Apollo.app/Apollo"
+            echo "Duplicate LC_RPATH entry removed"
+          fi
+
+          echo "Fake Signing Apollo Executable!"
+          ldid -S -M "Payload/Apollo.app/Apollo"
+          echo "Zipping NO-EXTENSIONS_GLASS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa"
+          zip -6 -rq "NO-EXTENSIONS_GLASS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" "Payload" -x "*/.*"
 
       - name: Generate release notes
         env:
@@ -121,8 +185,10 @@ jobs:
           name: Apollo v${{ steps.download-files.outputs.APOLLO_VERSION }} with ImprovedCustomApi v${{ steps.download-files.outputs.ICA_VERSION }}
           body_path: RELEASE_NOTES.md
           files: |
-            Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}.ipa
-            NO-EXTENSIONS_Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}.ipa
+            Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}/Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}.ipa
+            Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}/GLASS_Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}.ipa
+            NO-EXTENSIONS_Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}/NO-EXTENSIONS_Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}.ipa
+            NO-EXTENSIONS_Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}/NO-EXTENSIONS_GLASS_Apollo-${{ steps.download-files.outputs.APOLLO_VERSION }}_ImprovedCustomApi-${{ steps.download-files.outputs.ICA_VERSION }}.ipa
 
       - name: Upload to catbox
         if: env.CATBOX_UPLOAD == 'true'
@@ -135,9 +201,12 @@ jobs:
             exit 1
           fi
 
-          CATBOX_URL=$(curl -F "fileToUpload=@Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" https://catbox.moe/user/api.php)
-          CATBOX_URL_NO_EXT=$(curl -F "fileToUpload=@NO-EXTENSIONS-Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" https://catbox.moe/user/api.php)
-          
+          CATBOX_URL=$(curl -F "fileToUpload=@Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}/Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" https://catbox.moe/user/api.php)
+          CATBOX_URL_GLASS=$(curl -F "fileToUpload=@Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}/GLASS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" https://catbox.moe/user/api.php)
+
+          CATBOX_URL_NO_EXT=$(curl -F "fileToUpload=@NO-EXTENSIONS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" https://catbox.moe/user/api.php)
+          CATBOX_URL_NO_EXT_GLASS=$(curl -F "fileToUpload=@NO-EXTENSIONS_GLASS_Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}/NO-EXTENSIONS-Apollo-${APOLLO_VERSION}_ImprovedCustomApi-${ICA_VERSION}.ipa" https://catbox.moe/user/api.php)
+
           echo "CATBOX_URL=${CATBOX_URL}" >> "$GITHUB_ENV"
           echo "CATBOX_URL_NO_EXT=${CATBOX_URL_NO_EXT}" >> "$GITHUB_ENV"
 
@@ -156,15 +225,15 @@ jobs:
             echo "No changes detected, skipping commit."
           else
             git fetch origin main
-            
+
             git checkout -b new-release origin/main
             git checkout --detach HEAD
 
             git commit -m "update version to $RELEASE_TAG"
-            
+
             git checkout new-release
             git cherry-pick HEAD@{1}
-            
+
             git push origin new-release:main
           fi
 
@@ -172,4 +241,4 @@ jobs:
         run: |
           echo "### 📊 Workflow Summary" >> $GITHUB_STEP_SUMMARY
           echo "✅ New release created: v${{ steps.download-files.outputs.APOLLO_VERSION }}-${{ steps.download-files.outputs.ICA_VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "🔗 [View release](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.download-files.outputs.APOLLO_VERSION }}_${{ steps.download-files.outputs.ICA_VERSION }})" >> $GITHUB_STEP_SUMMARY  
+          echo "🔗 [View release](https://github.com/${{ github.repository }}/releases/tag/v${{ steps.download-files.outputs.APOLLO_VERSION }}_${{ steps.download-files.outputs.ICA_VERSION }})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Should close #72 

Entirely based off the work done by [@ryannair05](https://github.com/ryannair05) in [#63](https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/issues/63) as well JeffreyCA's additional [implementation](https://github.com/JeffreyCA/Apollo-ImprovedCustomApi?tab=readme-ov-file#ios-26-liquid-glass-patch).

Switch from Ubuntu runner to MacOS runner so `vtool` is available, but if this is not desired the modifications could likely be accomplished with [LIEF](https://lief.re/doc/latest/formats/macho/index.html#advance-parsing-writing) or similar tools.

Unfortunately the Mac version of `grep` does not support the -P option, but the desired behavior could be easily reimplemented with `sed`, but I felt that it was simpler to just use the tag as is. This also simplifies versioning in the future if there are ever future beta versions of ImprovedCustomAPI. I don't know if this would require changes around the `apps.json` and `apps_noext.json` as well changes in regards to the Liquid Glass version.

The actual implementation entails:
- Zip the file ourselves to avoid having to apply the ImprovedCustomAPI twice
- Use `vtool` to set the build version
- Fakesign the Apollo executable with `ldid`
- Zip up the Liquid Glass version
- do the same, but for the no extension version

Naming wise it's a bit disgusting, so I might clean that up in later commits.

When testing it, I was having issues with the step `Fetch latest release information` with `jq` throwing errors(`jq: error (at <stdin>:1): Cannot iterate over null (null)`), but I was unable to understand what was causing it. Rerunning the jobs until it eventually just worked was the solution. I don't know if this is because of the switch to the MacOS runner or if you had come across that yourself previously.

In the future it would be cool to potentially include a [Liquid Glass icon](https://github.com/JeffreyCA/Apollo-ImprovedCustomApi/issues/63#issuecomment-3321999572).